### PR TITLE
 ✨ wrap sitk.Transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://https://opensource.org/licenses/MIT)
 [![PyPI version](https://badge.fury.io/py/sitk-cli.svg)](https://badge.fury.io/py/sitk-cli)
 
-Create simple command line interface from functions that use SimpleITK images as arguments or return type.
+Create simple command line interface from functions that use SimpleITK images (and transforms) as arguments or return type.
 
 Install from PyPI:
 
@@ -33,6 +33,5 @@ def fill_holes_slice_by_slice(mask: sitk.Image) -> sitk.Image:
 if __name__ == "__main__":
     typer.run(make_cli(fill_holes_slice_by_slice))
 ```
-
 
 ![](./docs/demo.gif)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sitk-cli
-version = 0.2.0
+version = 0.3.0
 url = https://github.com/dyollb/sitk-cli
 description = Wrap SimpleITK functions as command lines
 long_description = file: README.md

--- a/src/sitk_cli/lib.py
+++ b/src/sitk_cli/lib.py
@@ -6,14 +6,20 @@ import typer
 from makefun import wraps
 
 
-def make_cli(func):
+def make_cli(func, output_arg_name="output"):
     """Make command line interface from function with sitk.Image args"""
     image_args = []
+    transform_args = []
 
     def _translate_param(p: Parameter):
         annotation, default = p.annotation, p.default
-        if issubclass(p.annotation, sitk.Image):
-            image_args.append(p.name)
+        if isclass(p.annotation) and issubclass(
+            p.annotation, (sitk.Image, sitk.Transform)
+        ):
+            if issubclass(p.annotation, sitk.Image):
+                image_args.append(p.name)
+            else:
+                transform_args.append(p.name)
             annotation = Path
             default = typer.Option(None) if p.default is None else typer.Option(...)
         elif p.default == Parameter.empty:
@@ -28,18 +34,18 @@ def make_cli(func):
     func_sig = signature(func)
 
     params = []
-    last_image_argument_idx = 0
     for idx, p in enumerate(func_sig.parameters.values()):
-        if issubclass(p.annotation, sitk.Image):
-            last_image_argument_idx = idx + 1
         params.append(_translate_param(p))
 
     return_type = func_sig.return_annotation
-    if return_type and isclass(return_type) and issubclass(return_type, sitk.Image):
-        params.insert(
-            last_image_argument_idx,
+    if (
+        return_type
+        and isclass(return_type)
+        and issubclass(return_type, (sitk.Image, sitk.Transform))
+    ):
+        params.append(
             Parameter(
-                "output",
+                output_arg_name,
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 default=None,
                 annotation=Path,
@@ -54,24 +60,31 @@ def make_cli(func):
         output_file: Path = None
         kwargs_inner = {}
         for k, v in kwargs.items():
-            if k == "output":
+            if k == output_arg_name:
                 output_file = v
                 continue
             if k in image_args and issubclass(type(v), Path):
                 v = sitk.ReadImage(f"{v}")
+            if k in transform_args and issubclass(type(v), Path):
+                v = sitk.ReadTransform(f"{v}")
             kwargs_inner[k] = v
 
         ret = func(*args, **kwargs_inner)
         if output_file and ret:
-            return sitk.WriteImage(ret, f"{output_file}")
+            if isinstance(ret, sitk.Image):
+                return sitk.WriteImage(ret, f"{output_file}")
+            else:
+                return sitk.WriteTransform(ret, f"{output_file}")
         return ret
 
     return func_wrapper
 
 
-def register_command(func, app: typer.Typer, func_name: str = None):
+def register_command(
+    func, app: typer.Typer, func_name: str = None, output_arg_name="output"
+):
     """Register function as command"""
-    func_cli = make_cli(func)
+    func_cli = make_cli(func, output_arg_name=output_arg_name)
 
     @app.command()
     @wraps(func_cli, func_name=func_name)

--- a/tests/test_make_cli.py
+++ b/tests/test_make_cli.py
@@ -15,6 +15,13 @@ def make_image(width: int, height: int) -> sitk.Image:
     return sitk.Image(width, height, sitk.sitkInt16)
 
 
+def register_api(
+    fixed: sitk.Image, moving: sitk.Image, init_transform: sitk.Transform
+) -> sitk.Transform:
+    tx = sitk.CenteredTransformInitializer(fixed, moving)
+    return sitk.CompositeTransform([init_transform, tx])
+
+
 def test_make_cli_image_arg():
     cli = sitk_cli.make_cli(get_shape)
     sig = signature(cli)
@@ -44,3 +51,14 @@ def test_make_cli_usage(tmp_path: Path):
 
     # check running without writing output file
     make_image_cli(width=32, height=64, output=None)
+
+
+def test_make_cli_transform_arg():
+    cli = sitk_cli.make_cli(register_api, output_arg_name="output_transform")
+    sig = signature(cli)
+
+    assert len(sig.parameters) == 4
+    assert issubclass(sig.parameters["fixed"].annotation, Path)
+    assert issubclass(sig.parameters["moving"].annotation, Path)
+    assert issubclass(sig.parameters["init_transform"].annotation, Path)
+    assert issubclass(sig.parameters["output_transform"].annotation, Path)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

This PR adds functionality to wrap arguments of type `sitk.Transform`, similar to `sitk.Image`
- `sitk.Transform` arguments/return types are replaced by `Path` arguments
- on execution, the transform is read from (written to) the path

<!-- Explain REVIEWERS what is this PR about -->

## How to test

run pytest

## Checklist

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] Unit tests for the changes and run locally with the command `pytest tests`
- [x] Runs on minimum Python version
- [x] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
