### PR TITLE
✨ rewrite register_command as decorator

### DIFF
--- a/.github/workflows/deploy_and_test.yml
+++ b/.github/workflows/deploy_and_test.yml
@@ -42,10 +42,15 @@ jobs:
           os: ubuntu-20.04,
           python-version: "3.9"
           }
+        - {
+          name: "ubuntu-20.04 - Python 3.10",
+          os: ubuntu-20.04,
+          python-version: "3.10"
+          }
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src_dir
     - name: Setup python ${{ matrix.config.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: upgrade code
+        args: ["--py37-plus"]
 
   - repo: https://github.com/hadialqattan/pycln
     rev: v1.2.5

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Actions Status](https://github.com/dyollb/segmantic/workflows/CI/badge.svg)](https://github.com/dyollb/sitk-cli/actions)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://https://opensource.org/licenses/MIT)
 [![PyPI version](https://badge.fury.io/py/sitk-cli.svg)](https://badge.fury.io/py/sitk-cli)
+<img src="https://img.shields.io/pypi/dm/sitk-cli.svg?label=pypi%20downloads&logo=python&logoColor=green"/>
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 ## Overview
 
-Create simple command line interface from functions that use [SimpleITK](https://github.com/SimpleITK/SimpleITK) images (and transforms) as arguments or return type.
-
+Create [Typer](https://github.com/tiangolo/typer) command line interface from functions that use [SimpleITK](https://github.com/SimpleITK/SimpleITK) images (and transforms) as arguments or return type.
 
 ```Python
 import SimpleITK as sitk
@@ -36,4 +35,5 @@ pip install sitk-cli
 ```
 
 ## Demo
+
 ![](./docs/demo.gif)

--- a/examples/pre_processing.py
+++ b/examples/pre_processing.py
@@ -1,16 +1,24 @@
+from typing import Optional
+
 import SimpleITK as sitk
 import typer
 
 from sitk_cli import register_command
 
+app = typer.Typer()
 
+
+@register_command(app)
 def median_filter(input: sitk.Image, radius: int) -> sitk.Image:
-    return sitk.Median(input, [radius] * input.GetDimension())
+    """Perform median filtering"""
+    image: sitk.Image = sitk.Median(input, [radius] * input.GetDimension())
+    return image
 
 
+@register_command(app)
 def bias_correct(
     input: sitk.Image,
-    mask: sitk.Image = None,
+    mask: Optional[sitk.Image] = None,
     shrink_factor: int = 4,
     num_fitting_levels: int = 4,
     num_iterations: int = 50,
@@ -34,14 +42,9 @@ def bias_correct(
 
     corrector.Execute(image, mask)
     log_bias_field = corrector.GetLogBiasFieldAsImage(input)
-    corrected_image_full_resolution = input / sitk.Exp(log_bias_field)
+    corrected_image_full_resolution: sitk.Image = input / sitk.Exp(log_bias_field)
     return corrected_image_full_resolution
 
 
 if __name__ == "__main__":
-    app = typer.Typer()
-
-    register_command(median_filter, app)
-    register_command(bias_correct, app)
-
     app()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sitk-cli
-version = 0.3.0
+version = 0.4.0
 url = https://github.com/dyollb/sitk-cli
 description = Wrap SimpleITK functions as command lines
 long_description = file: README.md

--- a/tests/test_register_cli.py
+++ b/tests/test_register_cli.py
@@ -1,0 +1,24 @@
+import SimpleITK as sitk
+import typer
+from typer.testing import CliRunner
+
+from sitk_cli import register_command
+
+app = typer.Typer()
+
+
+@register_command(app, func_name="centered-transform-initializer")
+def example_function(
+    fixed: sitk.Image, moving: sitk.Image, init_transform: sitk.Transform
+) -> sitk.Transform:
+    """Test function"""
+    tx = sitk.CenteredTransformInitializer(fixed, moving)
+    return sitk.CompositeTransform([init_transform, tx])
+
+
+def test_register_command():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "centered-transform-initializer" in result.stdout
+    assert "Test function" in result.stdout


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

The `register_command` function is now a proper decorator, that
- returns the original function, so it can be used with its original signature

Also fixed some type annotation issues, reported by `mypy-0.991`
- e.g. default None is not implicit Optional

<!-- Explain REVIEWERS what is this PR about -->

## Related issue/s

https://github.com/tiangolo/typer/issues/503

<!-- Enumerate REVIEWERS other issues

e.g.

- #4 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

