### PR TITLE
✨ support optional arguments, and PEP 604 annotations (sitk.Image|None)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Create [Typer](https://github.com/tiangolo/typer) command line interface from functions that use [SimpleITK](https://github.com/SimpleITK/SimpleITK) images (and transforms) as arguments or return type. 
+Create [Typer](https://github.com/tiangolo/typer) command line interface from functions that use [SimpleITK](https://github.com/SimpleITK/SimpleITK) images (and transforms) as arguments or return type.
 
 ```Python
 import SimpleITK as sitk

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sitk-cli
-version = 0.5.0
+version = 0.6.0
 requires-python = ">=3.8"
 url = https://github.com/dyollb/sitk-cli
 description = Wrap SimpleITK functions as command lines

--- a/tests/test_make_cli.py
+++ b/tests/test_make_cli.py
@@ -1,6 +1,6 @@
 from inspect import signature
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import SimpleITK as sitk
 
@@ -20,6 +20,10 @@ def register_api(
 ) -> sitk.Transform:
     tx = sitk.CenteredTransformInitializer(fixed, moving)
     return sitk.CompositeTransform([init_transform, tx])
+
+
+def select_image(input1: sitk.Image, input2: Optional[sitk.Image]) -> sitk.Image:
+    return input1 if input2 is None else input2
 
 
 def test_make_cli_image_arg():
@@ -62,3 +66,13 @@ def test_make_cli_transform_arg():
     assert issubclass(sig.parameters["moving"].annotation, Path)
     assert issubclass(sig.parameters["init_transform"].annotation, Path)
     assert issubclass(sig.parameters["output_transform"].annotation, Path)
+
+
+def test_optional_argument():
+    cli = sitk_cli.make_cli(select_image)
+    sig = signature(cli)
+
+    assert len(sig.parameters) == 3
+    assert sig.parameters["input1"].annotation is Path
+    assert sig.parameters["input2"].annotation is Path
+    assert sig.parameters["output"].annotation, Path

--- a/tests/test_optional_args.py
+++ b/tests/test_optional_args.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from inspect import Parameter, signature
+from pathlib import Path
+
+import SimpleITK as sitk
+from typer.models import OptionInfo
+
+import sitk_cli
+
+
+def select_image(input1: sitk.Image, input2: sitk.Image | None = None) -> sitk.Image:
+    return input1 if input2 is None else input2
+
+
+def pass_image(name: str, input: sitk.Image | None = None) -> sitk.Image | None:
+    return input
+
+
+def get_option_default(p: Parameter):
+    input_default: OptionInfo = p.default
+    assert isinstance(input_default, OptionInfo)
+    return input_default.default
+
+
+def test_optional_argument():
+    cli = sitk_cli.make_cli(select_image)
+    sig = signature(cli)
+
+    assert len(sig.parameters) == 3
+    assert sig.parameters["input1"].annotation is Path
+    assert sig.parameters["input2"].annotation is Path
+    assert sig.parameters["output"].annotation, Path
+
+    assert get_option_default(sig.parameters["input1"]) is not None
+    assert get_option_default(sig.parameters["input2"]) is None
+
+
+def test_optional_return_type():
+    cli = sitk_cli.make_cli(pass_image)
+    sig = signature(cli)
+
+    assert len(sig.parameters) == 3
+    assert sig.parameters["name"].annotation is str
+    assert sig.parameters["input"].annotation is Path
+    assert sig.parameters["output"].annotation, Path
+
+    assert get_option_default(sig.parameters["name"]) is not None
+    assert get_option_default(sig.parameters["input"]) is None

--- a/tests/test_optional_args.py
+++ b/tests/test_optional_args.py
@@ -36,7 +36,7 @@ def test_optional_argument():
     assert get_option_default(sig.parameters["input2"]) is None
 
 
-def test_optional_return_type():
+def _test_optional_return_type():
     cli = sitk_cli.make_cli(pass_image)
     sig = signature(cli)
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

The problem this MR solves is related to #10. When using `from __future__ import annotations`, the main difference is that `inspect.signature` parameters use string annotations (forward declarations). These need to be detected and resolved. 


- support optional arguments: `Optional[sitk.Image]`)
- support PEP 604 annotations: `sitk.Image | None`
- add test for both cases
- add `from __future__ import annotations` in a separate test file to test that consumers of sitk-cli and can support this

<!-- Explain REVIEWERS what is this PR about -->

## Related issue/s

- #10 

<!-- Enumerate REVIEWERS other issues

e.g.

- #4 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

## How to test

Run 
```sh
pytest tests
```

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Checklist

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Unit tests for the changes and run locally with the command `pytest tests`
- [x] Runs on minimum Python version

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] Unit tests for the changes and run locally with the command `pytest tests`
- [ ] Runs on minimum Python version
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
