### PR TITLE
🐛add fix/workaround for old python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sitk-cli
-version = 0.6.0
+version = 0.7.0
 requires-python = ">=3.8"
 url = https://github.com/dyollb/sitk-cli
 description = Wrap SimpleITK functions as command lines

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sitk-cli
-version = 0.7.0
+version = 0.7.0.post1
 requires-python = ">=3.8"
 url = https://github.com/dyollb/sitk-cli
 description = Wrap SimpleITK functions as command lines

--- a/src/sitk_cli/lib.py
+++ b/src/sitk_cli/lib.py
@@ -21,13 +21,11 @@ def make_cli(func, output_arg_name="output", globals=None, locals=None):
     def _parse_annotation(annotation):
         """handle Optional[A], Union[A, None] and A | None, and string annotations"""
         if isinstance(annotation, str):
-            if sys.version_info >= (3, 10):
-                annotation = eval(annotation)
-            else:
+            if sys.version_info < (3, 10):
                 if "|" in annotation:
                     types = ",".join(t.strip() for t in annotation.split("|"))
                     annotation = f"Union[{types}]"
-                annotation = eval(annotation, globals, locals)
+            annotation = eval(annotation, globals, locals)
 
         origin = get_origin(annotation)
         args = get_args(annotation)

--- a/src/sitk_cli/lib.py
+++ b/src/sitk_cli/lib.py
@@ -1,9 +1,9 @@
-
 import sys
 from inspect import Parameter, isclass, signature
 from pathlib import Path
 from typing import Optional, Union, get_args, get_origin
-if sys.version_info >= (3,10):
+
+if sys.version_info >= (3, 10):
     from types import UnionType as UnionType
 else:
     from typing import Union as UnionType
@@ -13,7 +13,7 @@ import typer
 from makefun import wraps
 
 
-def make_cli(func, output_arg_name="output"):
+def make_cli(func, output_arg_name="output", globals=None, locals=None):
     """Make command line interface from function with sitk.Image args"""
     image_args = []
     transform_args = []
@@ -21,13 +21,13 @@ def make_cli(func, output_arg_name="output"):
     def _parse_annotation(annotation):
         """handle Optional[A], Union[A, None] and A | None, and string annotations"""
         if isinstance(annotation, str):
-            if sys.version_info >= (3,10):
+            if sys.version_info >= (3, 10):
                 annotation = eval(annotation)
             else:
                 if "|" in annotation:
                     types = ",".join(t.strip() for t in annotation.split("|"))
                     annotation = f"Union[{types}]"
-                annotation = eval(annotation)
+                annotation = eval(annotation, globals, locals)
 
         origin = get_origin(annotation)
         args = get_args(annotation)
@@ -108,12 +108,18 @@ def make_cli(func, output_arg_name="output"):
 
 
 def register_command(
-    app: typer.Typer, func_name: Optional[str] = None, output_arg_name: str = "output"
+    app: typer.Typer,
+    func_name: Optional[str] = None,
+    output_arg_name: str = "output",
+    globals=None,
+    locals=None,
 ):
     """Register function as command"""
 
     def decorator(func):
-        func_cli = make_cli(func, output_arg_name=output_arg_name)
+        func_cli = make_cli(
+            func, output_arg_name=output_arg_name, globals=globals, locals=locals
+        )
 
         @app.command()
         @wraps(func_cli, func_name=func_name)

--- a/tests/example_function.py
+++ b/tests/example_function.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import SimpleITK as sitk
+import typer
+
+from sitk_cli import register_command
+
+
+class Mode(str, Enum):
+    moments = "moments"
+    geometry = "geometry"
+
+
+app = typer.Typer()
+
+
+@register_command(app, func_name="centered-transform-initializer", globals=globals())
+def example_function(
+    fixed: sitk.Image,
+    moving: sitk.Image,
+    mode: Mode = Mode.moments.value,  # type: ignore
+) -> sitk.Transform:
+    """Test function"""
+
+    operation_mode = (
+        sitk.CenteredTransformInitializerFilter.MOMENTS
+        if mode == Mode.moments.value
+        else sitk.CenteredTransformInitializerFilter.GEOMETRY
+    )
+    tx: sitk.Transform = sitk.CenteredTransformInitializer(
+        fixed, moving, sitk.Euler3DTransform(), operation_mode
+    )
+    return tx

--- a/tests/example_function.py
+++ b/tests/example_function.py
@@ -16,7 +16,9 @@ class Mode(str, Enum):
 app = typer.Typer()
 
 
-@register_command(app, func_name="centered-transform-initializer", globals=globals())
+@register_command(
+    app, func_name="centered-transform-initializer", locals=locals(), globals=globals()
+)
 def example_function(
     fixed: sitk.Image,
     moving: sitk.Image,

--- a/tests/test_register_cli.py
+++ b/tests/test_register_cli.py
@@ -1,22 +1,9 @@
-import SimpleITK as sitk
-import typer
 from typer.testing import CliRunner
-
-from sitk_cli import register_command
-
-app = typer.Typer()
-
-
-@register_command(app, func_name="centered-transform-initializer")
-def example_function(
-    fixed: sitk.Image, moving: sitk.Image, init_transform: sitk.Transform
-) -> sitk.Transform:
-    """Test function"""
-    tx = sitk.CenteredTransformInitializer(fixed, moving)
-    return sitk.CompositeTransform([init_transform, tx])
 
 
 def test_register_command():
+    from .example_function import app
+
     runner = CliRunner()
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_register_cli.py
+++ b/tests/test_register_cli.py
@@ -1,9 +1,9 @@
 from typer.testing import CliRunner
 
+from .example_function import app
+
 
 def test_register_command():
-    from .example_function import app
-
     runner = CliRunner()
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

This PR fixes issues related to using e.g. Enums as argument when `from __future__ import annotations` is used. 

In this situation, the annotation is provided as string and the line `annotation = eval(annotation, globals, locals)` raises a `NameError`. The workaround is to pass `locals` (or `globals`) to the decorator, so eval knows the class.

## Checklist

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Unit tests for the changes and run locally with the command `pytest tests`
- [x] Runs on minimum Python version
